### PR TITLE
Add ALF

### DIFF
--- a/hobot_cicd/requirements.txt
+++ b/hobot_cicd/requirements.txt
@@ -4,29 +4,13 @@ dm_control
 numpy-quaternion
 
 # Alf Dependencies
+alf@git+https://github.com/HorizonRobotics/alf.git@hobot_01052023
 atari_py==0.2.9
-box2d-py
-cpplint
-clang-format==9.0
-fasteners
-gin-config@git+https://github.com/HorizonRobotics/gin-config.git
 gym==0.19.0
-gym3==0.3.3
-h5py
-matplotlib
-numpy
-opencv-python
-pathos==0.2.4
-pillow
-procgen==0.10.7
-psutil
 pybullet==3.2.5
-pyglet==1.3.2  # higher version breaks classic control renderi
-rectangle-packer==2.0.0
 torch==1.12.1+cpu
 torchvision==0.13.1+cpu
 torchtext==0.13.1
-cnest==1.0.4
 
 # Tools
 pydocstyle==4.0.0


### PR DESCRIPTION
We need to add ALF into the CI image in order to run some test that depends on ALF, e.g. network, training etc.